### PR TITLE
std::vector to std::array

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -6,12 +6,14 @@ int main() {
     mat<2> x(s,v);
     mat<2> yy(10.0, 20, 30, 40);
     mat<2> qq(yy);
+    std::cout << s << std::endl;
     
     std::cout << x << std::endl;
     std::cout << yy << std::endl;
+    std::cout << qq << std::endl;
     //
     const GLfloat *pt = qq;
-    for(int i=0;i<8;i++) {
+    for(int i=0;i<4;i++) {
         std::cout << *pt << std::endl;
         pt++;
     }

--- a/main.cpp
+++ b/main.cpp
@@ -1,23 +1,20 @@
 #include "sand.h"
 
 int main() {
-    vec<2> s(20, 10);
-    vec<2> v(10, 1000);
-    mat<2> x(s,v);
-    mat<2> yy(10.0, 20, 30, 40);
-    mat<2> qq(yy);
+    vec<5> s(10,20,10,20,50);
+    vec<2> t(10);
+    vec<2> q(t);
     std::cout << s << std::endl;
+    t[1] = 0;
+    std::cout << t << std::endl;
+    std::cout << q << std::endl;
+    mat<2> a(20);
+    mat<2> tt(10, 20, 40, 30);
+    std::cout << a << std::endl;
     
-    std::cout << x << std::endl;
-    std::cout << yy << std::endl;
-    std::cout << qq << std::endl;
-    //
-    const GLfloat *pt = qq;
-    for(int i=0;i<4;i++) {
-        std::cout << *pt << std::endl;
-        pt++;
-    }
-    
+    tt[0][1] = 10;
+    float* ss = tt;
+    for(int i=0;i<4;i++) { std::cout << *ss << std::endl; ss++;}
 
     return 0;
 }

--- a/mat.h
+++ b/mat.h
@@ -10,18 +10,18 @@ namespace Sand {
 template<int N>
 class mat {
 
-    std::vector<vec<N>> m;
+    std::array<vec<N>, N> m;
 
 private:
     // vector generator init for float
     template<int curm, int curv, typename T>
-    void vec_generate(std::vector<T> &v) {
+    void vec_generate(std::array<T, N> &v) {
         m[curm] = vec<N>(v);
     }
     
     // vector generator recursion for float
     template<int curm, int curv, typename... T, typename U>
-    void vec_generate(std::vector<U> &v, U first, T... rest) {
+    void vec_generate(std::array<U, N> &v, U first, T... rest) {
         if constexpr (curv == N) {
             m[curm] = vec<N>(v);
             vec_generate<curm+1, 0>(v, first, rest...);
@@ -37,8 +37,7 @@ private:
     void mat_float(T... vals) {
         static_assert(N * N == sizeof...(vals),
              "The number of parameters should be N square.");
-        m = std::vector<vec<N>>(N);
-        auto v = std::vector<GLfloat>(N);
+        auto v = std::array<GLfloat, N>();
         vec_generate<0, 0>(v, vals...); 
     }
 
@@ -47,7 +46,7 @@ private:
     void mat_vec(T&&... vals) {
         static_assert(N == sizeof...(vals), 
             "The number of parameters should be N");
-        m = std::vector<vec<N>>{vals...};
+        m = std::array<vec<N>, N>{vals...};
     }
     
     
@@ -60,7 +59,6 @@ public:
     //
 
     mat(const GLfloat d = GLfloat(1.0))  { // Diagonal
-        m = std::vector<vec<N>>(N);
         for(int i = 0; i < N; i++)
             m[i][i] = d;
     }
@@ -81,32 +79,32 @@ public:
     
 
     mat(const mat<N>& m) : m(m.m) {}
-    mat(const std::vector<vec<N>>& _m) : m(_m) {}
+    mat(const std::array<vec<N>, N>& _m) : m(_m) {}
 
     vec<N>& operator [] (int i) { return m[i]; }
     const vec<N>& operator [] (int i) const { return m[i]; }
 
     mat operator-() const {
-        std::vector<vec<N>> res(N);
+        std::array<vec<N>, N> res;
         std::transform(m.begin(), m.end(), res.begin(),
             [](vec<N> v) -> vec<N> { return -v; });
         return mat(res);
     }
 
     mat operator + (const mat& _m) const {
-        std::vector<vec<N>> res(N);
+        std::array<vec<N>, N> res;
         std::transform(m.begin(), m.end(), _m.m.begin(), res.begin(), std::plus<>{}); 
         return mat(res);
     }
 
     mat operator - (const mat& _m) const {
-        std::vector<vec<N>> res(N);
+        std::array<vec<N>, N> res;
         std::transform(m.begin(), m.end(), _m.m.begin(), res.begin(), std::minus<>{});
         return mat(res);
     }
 
     mat operator * (const GLfloat s) const {
-        std::vector<vec<N>> res(N);
+        std::array<vec<N>, N> res;
         std::transform(m.begin(), m.end(), res.begin(),
                 [s](vec<N> v) -> vec<N> { return s * v; });
         return mat(res);
@@ -116,7 +114,7 @@ public:
     { return m * s; }
 
     mat operator * (const mat& _m) const {
-        std::vector<vec<N>> res(N);
+        std::array<vec<N>, N> res;
         for (int i = 0; i < N; i++)
             for(int j = 0; j < N; j++)
                 for (int k = 0; k < N; k++)
@@ -125,7 +123,7 @@ public:
     }
 
     vec<N> operator * (const vec<N>& v) const {
-        std::vector<GLfloat> res(N);
+        std::array<GLfloat, N> res;
         std::transform(m.m.begin(), m.m.end(), res.begin(),
                 [v](vec<N> _v) -> GLfloat { return dot(v, _v); });
         return vec(res);
@@ -182,174 +180,174 @@ public:
 };
 
 
-// Non-class matrix methods
+// // Non-class matrix methods
 
-template<int N>
-inline mat<N> matrixCompMult(const mat<N>& A, const mat<N>& B) {
-    std::vector<vec<N>> res(N);
-    std::transform(A.begin(), A.end(), B.begin(), res.begin(), std::multiplies<>{});
-    return mat(res);
-}
+// template<int N>
+// inline mat<N> matrixCompMult(const mat<N>& A, const mat<N>& B) {
+//     std::array<vec<N>, N> res;
+//     std::transform(A.begin(), A.end(), B.begin(), res.begin(), std::multiplies<>{});
+//     return mat(res);
+// }
 
-template<int N>
-inline mat<N> transpose(const mat<N>& A) {
-    std::vector<vec<N>> res(N, vec<N>(0));
-    for(int i=0;i<N;i++) for(int j=0;j<N;j++) res[j][i] = A[i][j];
-    return mat(res);
-}
-
-
-// Matrix Methods
-
-#define Error(str) std::cerr << "[" __FILE__ ":" << __LINE__ << "] " \
-    << str << std::endl
-
-inline mat<4> RotateX(const GLfloat theta) {
-    GLfloat angle = DegreesToRadians * theta;
-    mat<4> c;
-    c[2][2] = c[1][1] = cos(angle);
-    c[2][1] = sin(angle);
-    c[1][2] = -c[2][1];
-    return c;
-}
-
-inline mat<4> RotateY(const GLfloat theta) {
-    GLfloat angle = DegreesToRadians * theta;
-
-    mat<4> c;
-    c[2][2] = c[0][0] = cos(angle);
-    c[0][2] = sin(angle);
-    c[2][0] = -c[0][2];
-    return c;
-}
-
-inline mat<4> RotateZ(const GLfloat theta) {
-    GLfloat angle = DegreesToRadians * theta;
-    mat<4> c;
-    c[0][0] = c[1][1] = cos(angle);
-    c[1][0] = sin(angle);
-    c[0][1] = -c[1][0];
-    return c;
-}
-
-inline mat<4> Translate(const GLfloat x, const GLfloat y, const GLfloat z) {
-    mat<4> c;
-    c[0][3] = x; c[1][3] = y; c[2][3] = z;
-    return c;
-}
-
-inline mat<4> Translate(const vec<3>& v) {
-    return Translate(v[0], v[1], v[2]);
-}
-
-inline mat<4> Translate(const vec<4>& v) {
-    return Translate(v[0], v[1], v[2]);
-}
+// template<int N>
+// inline mat<N> transpose(const mat<N>& A) {
+//     std::array<vec<N>, N> res;
+//     for(int i=0;i<N;i++) for(int j=0;j<N;j++) res[j][i] = A[i][j];
+//     return mat(res);
+// }
 
 
-inline mat<4> Scale(const GLfloat x, const GLfloat y, const GLfloat z) {
-    mat<4> c;
-    c[0][0] = x;
-    c[1][1] = y;
-    c[2][2] = z;
-    return c;
-}
+// // Matrix Methods
 
-inline mat<4> Scale(const vec<3>& v) {
-    return Scale(v[0], v[1], v[2]);
-}
+// #define Error(str) std::cerr << "[" __FILE__ ":" << __LINE__ << "] "
+//     << str << std::endl
+
+// inline mat<4> RotateX(const GLfloat theta) {
+//     GLfloat angle = DegreesToRadians * theta;
+//     mat<4> c;
+//     c[2][2] = c[1][1] = cos(angle);
+//     c[2][1] = sin(angle);
+//     c[1][2] = -c[2][1];
+//     return c;
+// }
+
+// inline mat<4> RotateY(const GLfloat theta) {
+//     GLfloat angle = DegreesToRadians * theta;
+
+//     mat<4> c;
+//     c[2][2] = c[0][0] = cos(angle);
+//     c[0][2] = sin(angle);
+//     c[2][0] = -c[0][2];
+//     return c;
+// }
+
+// inline mat<4> RotateZ(const GLfloat theta) {
+//     GLfloat angle = DegreesToRadians * theta;
+//     mat<4> c;
+//     c[0][0] = c[1][1] = cos(angle);
+//     c[1][0] = sin(angle);
+//     c[0][1] = -c[1][0];
+//     return c;
+// }
+
+// inline mat<4> Translate(const GLfloat x, const GLfloat y, const GLfloat z) {
+//     mat<4> c;
+//     c[0][3] = x; c[1][3] = y; c[2][3] = z;
+//     return c;
+// }
+
+// inline mat<4> Translate(const vec<3>& v) {
+//     return Translate(v[0], v[1], v[2]);
+// }
+
+// inline mat<4> Translate(const vec<4>& v) {
+//     return Translate(v[0], v[1], v[2]);
+// }
 
 
-// Projection Transformations
+// inline mat<4> Scale(const GLfloat x, const GLfloat y, const GLfloat z) {
+//     mat<4> c;
+//     c[0][0] = x;
+//     c[1][1] = y;
+//     c[2][2] = z;
+//     return c;
+// }
+
+// inline mat<4> Scale(const vec<3>& v) {
+//     return Scale(v[0], v[1], v[2]);
+// }
+
+
+// // Projection Transformations
 
 
 
-inline mat<4> Ortho( const GLfloat left, const GLfloat right,
-           const GLfloat bottom, const GLfloat top,
-           const GLfloat zNear, const GLfloat zFar ) {
-    mat<4> c;
-    c[0][0] = 2.0/(right - left);
-    c[1][1] = 2.0/(top - bottom);
-    c[2][2] = 2.0/(zNear - zFar);
-    c[3][3] = 1.0;
-    c[0][3] = -(right + left)/(right - left);
-    c[1][3] = -(top + bottom)/(top - bottom);
-    c[2][3] = -(zFar + zNear)/(zFar - zNear);
-    return c;
-}
+// inline mat<4> Ortho( const GLfloat left, const GLfloat right,
+//            const GLfloat bottom, const GLfloat top,
+//            const GLfloat zNear, const GLfloat zFar ) {
+//     mat<4> c;
+//     c[0][0] = 2.0/(right - left);
+//     c[1][1] = 2.0/(top - bottom);
+//     c[2][2] = 2.0/(zNear - zFar);
+//     c[3][3] = 1.0;
+//     c[0][3] = -(right + left)/(right - left);
+//     c[1][3] = -(top + bottom)/(top - bottom);
+//     c[2][3] = -(zFar + zNear)/(zFar - zNear);
+//     return c;
+// }
 
-inline mat<4> Ortho2D( const GLfloat left, const GLfloat right,
-             const GLfloat bottom, const GLfloat top ) {
-    return Ortho( left, right, bottom, top, -1.0, 1.0 );
-}
+// inline mat<4> Ortho2D( const GLfloat left, const GLfloat right,
+//              const GLfloat bottom, const GLfloat top ) {
+//     return Ortho( left, right, bottom, top, -1.0, 1.0 );
+// }
 
-inline mat<4> Frustum( const GLfloat left, const GLfloat right,
-             const GLfloat bottom, const GLfloat top,
-             const GLfloat zNear, const GLfloat zFar ) {
-    mat<4> c;
-    c[0][0] = 2.0*zNear/(right - left);
-    c[0][2] = (right + left)/(right - left);
-    c[1][1] = 2.0*zNear/(top - bottom);
-    c[1][2] = (top + bottom)/(top - bottom);
-    c[2][2] = -(zFar + zNear)/(zFar - zNear);
-    c[2][3] = -2.0*zFar*zNear/(zFar - zNear);
-    c[3][2] = -1.0;
-    c[3][3] = 0.0;
-    return c;
-}
+// inline mat<4> Frustum( const GLfloat left, const GLfloat right,
+//              const GLfloat bottom, const GLfloat top,
+//              const GLfloat zNear, const GLfloat zFar ) {
+//     mat<4> c;
+//     c[0][0] = 2.0*zNear/(right - left);
+//     c[0][2] = (right + left)/(right - left);
+//     c[1][1] = 2.0*zNear/(top - bottom);
+//     c[1][2] = (top + bottom)/(top - bottom);
+//     c[2][2] = -(zFar + zNear)/(zFar - zNear);
+//     c[2][3] = -2.0*zFar*zNear/(zFar - zNear);
+//     c[3][2] = -1.0;
+//     c[3][3] = 0.0;
+//     return c;
+// }
 
-inline mat<4> Perspective( const GLfloat fovy, const GLfloat aspect,
-                 const GLfloat zNear, const GLfloat zFar) {
-    GLfloat top   = tan(fovy*DegreesToRadians/2) * zNear;
-    GLfloat right = top * aspect;
+// inline mat<4> Perspective( const GLfloat fovy, const GLfloat aspect,
+//                  const GLfloat zNear, const GLfloat zFar) {
+//     GLfloat top   = tan(fovy*DegreesToRadians/2) * zNear;
+//     GLfloat right = top * aspect;
     
-    mat<4> c;
-    c[0][0] = zNear/right;
-    c[1][1] = zNear/top;
-    c[2][2] = -(zFar + zNear)/(zFar - zNear);
-    c[2][3] = -2.0*zFar*zNear/(zFar - zNear);
-    c[3][2] = -1.0;
-    c[3][3] = 0.0;
-    return c;
-}
+//     mat<4> c;
+//     c[0][0] = zNear/right;
+//     c[1][1] = zNear/top;
+//     c[2][2] = -(zFar + zNear)/(zFar - zNear);
+//     c[2][3] = -2.0*zFar*zNear/(zFar - zNear);
+//     c[3][2] = -1.0;
+//     c[3][3] = 0.0;
+//     return c;
+// }
 
-//----------------------------------------------------------------------------
-//
-//  Viewing transformation matrix generation
-//
+// //----------------------------------------------------------------------------
+// //
+// //  Viewing transformation matrix generation
+// //
 
-inline mat<4> LookAt( const vec<4>& eye, const vec<4>& at, const vec<4>& up ) {
-    vec<4> n = normalize(eye - at);
-    vec<4> u = vec<4>(normalize(cross(up,n)), GLfloat(0.0));
-    vec<4> v = vec<4>(normalize(cross(n,u)), GLfloat(0.0));
-    vec<4> t = vec<4>(0.0, 0.0, 0.0, 1.0);
-    mat<4> c = mat<4>(u, v, n, t);
-    return c * Translate( -eye );
-}
+// inline mat<4> LookAt( const vec<4>& eye, const vec<4>& at, const vec<4>& up ) {
+//     vec<4> n = normalize(eye - at);
+//     vec<4> u = vec<4>(normalize(cross(up,n)), GLfloat(0.0));
+//     vec<4> v = vec<4>(normalize(cross(n,u)), GLfloat(0.0));
+//     vec<4> t = vec<4>(0.0, 0.0, 0.0, 1.0);
+//     mat<4> c = mat<4>(u, v, n, t);
+//     return c * Translate( -eye );
+// }
 
-//----------------------------------------------------------------------------
-//
-// Generates a Normal Matrix
-//
-inline mat<3> Normal( const mat<4>& c) {
-    mat<3> d;
-    GLfloat det;
+// //----------------------------------------------------------------------------
+// //
+// // Generates a Normal Matrix
+// //
+// inline mat<3> Normal( const mat<4>& c) {
+//     mat<3> d;
+//     GLfloat det;
     
-    det = c[0][0]*c[1][1]*c[2][2]+c[0][1]*c[1][2]*c[2][1]+c[0][2]*c[1][0]*c[2][1]
-    -c[2][0]*c[1][1]*c[0][2]-c[1][0]*c[0][1]*c[2][2]-c[0][0]*c[1][2]*c[2][1];
+//     det = c[0][0]*c[1][1]*c[2][2]+c[0][1]*c[1][2]*c[2][1]+c[0][2]*c[1][0]*c[2][1]
+//     -c[2][0]*c[1][1]*c[0][2]-c[1][0]*c[0][1]*c[2][2]-c[0][0]*c[1][2]*c[2][1];
     
-    d[0][0] = (c[1][1]*c[2][2]-c[1][2]*c[2][1])/det;
-    d[0][1] = -(c[1][0]*c[2][2]-c[1][2]*c[2][0])/det;
-    d[0][2] =  (c[1][0]*c[2][1]-c[1][1]*c[2][0])/det;
-    d[1][0] = -(c[0][1]*c[2][2]-c[0][2]*c[2][1])/det;
-    d[1][1] = (c[0][0]*c[2][2]-c[0][2]*c[2][0])/det;
-    d[1][2] = -(c[0][0]*c[2][1]-c[0][1]*c[2][0])/det;
-    d[2][0] =  (c[0][1]*c[1][2]-c[0][2]*c[1][1])/det;
-    d[2][1] = -(c[0][0]*c[1][2]-c[0][2]*c[1][0])/det;
-    d[2][2] = (c[0][0]*c[1][1]-c[1][0]*c[0][1])/det;
+//     d[0][0] = (c[1][1]*c[2][2]-c[1][2]*c[2][1])/det;
+//     d[0][1] = -(c[1][0]*c[2][2]-c[1][2]*c[2][0])/det;
+//     d[0][2] =  (c[1][0]*c[2][1]-c[1][1]*c[2][0])/det;
+//     d[1][0] = -(c[0][1]*c[2][2]-c[0][2]*c[2][1])/det;
+//     d[1][1] = (c[0][0]*c[2][2]-c[0][2]*c[2][0])/det;
+//     d[1][2] = -(c[0][0]*c[2][1]-c[0][1]*c[2][0])/det;
+//     d[2][0] =  (c[0][1]*c[1][2]-c[0][2]*c[1][1])/det;
+//     d[2][1] = -(c[0][0]*c[1][2]-c[0][2]*c[1][0])/det;
+//     d[2][2] = (c[0][0]*c[1][1]-c[1][0]*c[0][1])/det;
     
-    return d;
-}
+//     return d;
+// }
 
 } // namespace Sand
 

--- a/mat.h
+++ b/mat.h
@@ -64,7 +64,7 @@ public:
     }
 
     template<typename... Fs, 
-        std::enable_if_t<std::conjunction_v<std::is_arithmetic<Fs>...>, bool> = true
+        std::enable_if_t<std::conjunction_v<std::is_arithmetic<Fs>...> && (sizeof...(Fs) > 1), bool> = true
     >
     mat(const Fs&... vals) {
         mat_float(static_cast<GLfloat>(vals)...);
@@ -174,180 +174,180 @@ public:
         return static_cast<const GLfloat*>(m[0]);
     }
 
-    operator GLfloat* () const {
+    operator GLfloat* () {
         return static_cast<GLfloat*>(m[0]);
     }
 };
 
 
-// // Non-class matrix methods
+// Non-class matrix methods
 
-// template<int N>
-// inline mat<N> matrixCompMult(const mat<N>& A, const mat<N>& B) {
-//     std::array<vec<N>, N> res;
-//     std::transform(A.begin(), A.end(), B.begin(), res.begin(), std::multiplies<>{});
-//     return mat(res);
-// }
+template<int N>
+inline mat<N> matrixCompMult(const mat<N>& A, const mat<N>& B) {
+    std::array<vec<N>, N> res;
+    std::transform(A.begin(), A.end(), B.begin(), res.begin(), std::multiplies<>{});
+    return mat(res);
+}
 
-// template<int N>
-// inline mat<N> transpose(const mat<N>& A) {
-//     std::array<vec<N>, N> res;
-//     for(int i=0;i<N;i++) for(int j=0;j<N;j++) res[j][i] = A[i][j];
-//     return mat(res);
-// }
-
-
-// // Matrix Methods
-
-// #define Error(str) std::cerr << "[" __FILE__ ":" << __LINE__ << "] "
-//     << str << std::endl
-
-// inline mat<4> RotateX(const GLfloat theta) {
-//     GLfloat angle = DegreesToRadians * theta;
-//     mat<4> c;
-//     c[2][2] = c[1][1] = cos(angle);
-//     c[2][1] = sin(angle);
-//     c[1][2] = -c[2][1];
-//     return c;
-// }
-
-// inline mat<4> RotateY(const GLfloat theta) {
-//     GLfloat angle = DegreesToRadians * theta;
-
-//     mat<4> c;
-//     c[2][2] = c[0][0] = cos(angle);
-//     c[0][2] = sin(angle);
-//     c[2][0] = -c[0][2];
-//     return c;
-// }
-
-// inline mat<4> RotateZ(const GLfloat theta) {
-//     GLfloat angle = DegreesToRadians * theta;
-//     mat<4> c;
-//     c[0][0] = c[1][1] = cos(angle);
-//     c[1][0] = sin(angle);
-//     c[0][1] = -c[1][0];
-//     return c;
-// }
-
-// inline mat<4> Translate(const GLfloat x, const GLfloat y, const GLfloat z) {
-//     mat<4> c;
-//     c[0][3] = x; c[1][3] = y; c[2][3] = z;
-//     return c;
-// }
-
-// inline mat<4> Translate(const vec<3>& v) {
-//     return Translate(v[0], v[1], v[2]);
-// }
-
-// inline mat<4> Translate(const vec<4>& v) {
-//     return Translate(v[0], v[1], v[2]);
-// }
+template<int N>
+inline mat<N> transpose(const mat<N>& A) {
+    std::array<vec<N>, N> res;
+    for(int i=0;i<N;i++) for(int j=0;j<N;j++) res[j][i] = A[i][j];
+    return mat(res);
+}
 
 
-// inline mat<4> Scale(const GLfloat x, const GLfloat y, const GLfloat z) {
-//     mat<4> c;
-//     c[0][0] = x;
-//     c[1][1] = y;
-//     c[2][2] = z;
-//     return c;
-// }
+// Matrix Methods
 
-// inline mat<4> Scale(const vec<3>& v) {
-//     return Scale(v[0], v[1], v[2]);
-// }
+#define Error(str) std::cerr << "[" __FILE__ ":" << __LINE__ << "] " \
+    << str << std::endl
+
+inline mat<4> RotateX(const GLfloat theta) {
+    GLfloat angle = DegreesToRadians * theta;
+    mat<4> c;
+    c[2][2] = c[1][1] = cos(angle);
+    c[2][1] = sin(angle);
+    c[1][2] = -c[2][1];
+    return c;
+}
+
+inline mat<4> RotateY(const GLfloat theta) {
+    GLfloat angle = DegreesToRadians * theta;
+
+    mat<4> c;
+    c[2][2] = c[0][0] = cos(angle);
+    c[0][2] = sin(angle);
+    c[2][0] = -c[0][2];
+    return c;
+}
+
+inline mat<4> RotateZ(const GLfloat theta) {
+    GLfloat angle = DegreesToRadians * theta;
+    mat<4> c;
+    c[0][0] = c[1][1] = cos(angle);
+    c[1][0] = sin(angle);
+    c[0][1] = -c[1][0];
+    return c;
+}
+
+inline mat<4> Translate(const GLfloat x, const GLfloat y, const GLfloat z) {
+    mat<4> c;
+    c[0][3] = x; c[1][3] = y; c[2][3] = z;
+    return c;
+}
+
+inline mat<4> Translate(const vec<3>& v) {
+    return Translate(v[0], v[1], v[2]);
+}
+
+inline mat<4> Translate(const vec<4>& v) {
+    return Translate(v[0], v[1], v[2]);
+}
 
 
-// // Projection Transformations
+inline mat<4> Scale(const GLfloat x, const GLfloat y, const GLfloat z) {
+    mat<4> c;
+    c[0][0] = x;
+    c[1][1] = y;
+    c[2][2] = z;
+    return c;
+}
+
+inline mat<4> Scale(const vec<3>& v) {
+    return Scale(v[0], v[1], v[2]);
+}
+
+
+// Projection Transformations
 
 
 
-// inline mat<4> Ortho( const GLfloat left, const GLfloat right,
-//            const GLfloat bottom, const GLfloat top,
-//            const GLfloat zNear, const GLfloat zFar ) {
-//     mat<4> c;
-//     c[0][0] = 2.0/(right - left);
-//     c[1][1] = 2.0/(top - bottom);
-//     c[2][2] = 2.0/(zNear - zFar);
-//     c[3][3] = 1.0;
-//     c[0][3] = -(right + left)/(right - left);
-//     c[1][3] = -(top + bottom)/(top - bottom);
-//     c[2][3] = -(zFar + zNear)/(zFar - zNear);
-//     return c;
-// }
+inline mat<4> Ortho( const GLfloat left, const GLfloat right,
+           const GLfloat bottom, const GLfloat top,
+           const GLfloat zNear, const GLfloat zFar ) {
+    mat<4> c;
+    c[0][0] = 2.0/(right - left);
+    c[1][1] = 2.0/(top - bottom);
+    c[2][2] = 2.0/(zNear - zFar);
+    c[3][3] = 1.0;
+    c[0][3] = -(right + left)/(right - left);
+    c[1][3] = -(top + bottom)/(top - bottom);
+    c[2][3] = -(zFar + zNear)/(zFar - zNear);
+    return c;
+}
 
-// inline mat<4> Ortho2D( const GLfloat left, const GLfloat right,
-//              const GLfloat bottom, const GLfloat top ) {
-//     return Ortho( left, right, bottom, top, -1.0, 1.0 );
-// }
+inline mat<4> Ortho2D( const GLfloat left, const GLfloat right,
+             const GLfloat bottom, const GLfloat top ) {
+    return Ortho( left, right, bottom, top, -1.0, 1.0 );
+}
 
-// inline mat<4> Frustum( const GLfloat left, const GLfloat right,
-//              const GLfloat bottom, const GLfloat top,
-//              const GLfloat zNear, const GLfloat zFar ) {
-//     mat<4> c;
-//     c[0][0] = 2.0*zNear/(right - left);
-//     c[0][2] = (right + left)/(right - left);
-//     c[1][1] = 2.0*zNear/(top - bottom);
-//     c[1][2] = (top + bottom)/(top - bottom);
-//     c[2][2] = -(zFar + zNear)/(zFar - zNear);
-//     c[2][3] = -2.0*zFar*zNear/(zFar - zNear);
-//     c[3][2] = -1.0;
-//     c[3][3] = 0.0;
-//     return c;
-// }
+inline mat<4> Frustum( const GLfloat left, const GLfloat right,
+             const GLfloat bottom, const GLfloat top,
+             const GLfloat zNear, const GLfloat zFar ) {
+    mat<4> c;
+    c[0][0] = 2.0*zNear/(right - left);
+    c[0][2] = (right + left)/(right - left);
+    c[1][1] = 2.0*zNear/(top - bottom);
+    c[1][2] = (top + bottom)/(top - bottom);
+    c[2][2] = -(zFar + zNear)/(zFar - zNear);
+    c[2][3] = -2.0*zFar*zNear/(zFar - zNear);
+    c[3][2] = -1.0;
+    c[3][3] = 0.0;
+    return c;
+}
 
-// inline mat<4> Perspective( const GLfloat fovy, const GLfloat aspect,
-//                  const GLfloat zNear, const GLfloat zFar) {
-//     GLfloat top   = tan(fovy*DegreesToRadians/2) * zNear;
-//     GLfloat right = top * aspect;
+inline mat<4> Perspective( const GLfloat fovy, const GLfloat aspect,
+                 const GLfloat zNear, const GLfloat zFar) {
+    GLfloat top   = tan(fovy*DegreesToRadians/2) * zNear;
+    GLfloat right = top * aspect;
     
-//     mat<4> c;
-//     c[0][0] = zNear/right;
-//     c[1][1] = zNear/top;
-//     c[2][2] = -(zFar + zNear)/(zFar - zNear);
-//     c[2][3] = -2.0*zFar*zNear/(zFar - zNear);
-//     c[3][2] = -1.0;
-//     c[3][3] = 0.0;
-//     return c;
-// }
+    mat<4> c;
+    c[0][0] = zNear/right;
+    c[1][1] = zNear/top;
+    c[2][2] = -(zFar + zNear)/(zFar - zNear);
+    c[2][3] = -2.0*zFar*zNear/(zFar - zNear);
+    c[3][2] = -1.0;
+    c[3][3] = 0.0;
+    return c;
+}
 
-// //----------------------------------------------------------------------------
-// //
-// //  Viewing transformation matrix generation
-// //
+//----------------------------------------------------------------------------
+//
+//  Viewing transformation matrix generation
+//
 
-// inline mat<4> LookAt( const vec<4>& eye, const vec<4>& at, const vec<4>& up ) {
-//     vec<4> n = normalize(eye - at);
-//     vec<4> u = vec<4>(normalize(cross(up,n)), GLfloat(0.0));
-//     vec<4> v = vec<4>(normalize(cross(n,u)), GLfloat(0.0));
-//     vec<4> t = vec<4>(0.0, 0.0, 0.0, 1.0);
-//     mat<4> c = mat<4>(u, v, n, t);
-//     return c * Translate( -eye );
-// }
+inline mat<4> LookAt( const vec<4>& eye, const vec<4>& at, const vec<4>& up ) {
+    vec<4> n = normalize(eye - at);
+    vec<4> u = vec<4>(normalize(cross(up,n)), GLfloat(0.0));
+    vec<4> v = vec<4>(normalize(cross(n,u)), GLfloat(0.0));
+    vec<4> t = vec<4>(0.0, 0.0, 0.0, 1.0);
+    mat<4> c = mat<4>(u, v, n, t);
+    return c * Translate( -eye );
+}
 
-// //----------------------------------------------------------------------------
-// //
-// // Generates a Normal Matrix
-// //
-// inline mat<3> Normal( const mat<4>& c) {
-//     mat<3> d;
-//     GLfloat det;
+//----------------------------------------------------------------------------
+//
+// Generates a Normal Matrix
+//
+inline mat<3> Normal( const mat<4>& c) {
+    mat<3> d;
+    GLfloat det;
     
-//     det = c[0][0]*c[1][1]*c[2][2]+c[0][1]*c[1][2]*c[2][1]+c[0][2]*c[1][0]*c[2][1]
-//     -c[2][0]*c[1][1]*c[0][2]-c[1][0]*c[0][1]*c[2][2]-c[0][0]*c[1][2]*c[2][1];
+    det = c[0][0]*c[1][1]*c[2][2]+c[0][1]*c[1][2]*c[2][1]+c[0][2]*c[1][0]*c[2][1]
+    -c[2][0]*c[1][1]*c[0][2]-c[1][0]*c[0][1]*c[2][2]-c[0][0]*c[1][2]*c[2][1];
     
-//     d[0][0] = (c[1][1]*c[2][2]-c[1][2]*c[2][1])/det;
-//     d[0][1] = -(c[1][0]*c[2][2]-c[1][2]*c[2][0])/det;
-//     d[0][2] =  (c[1][0]*c[2][1]-c[1][1]*c[2][0])/det;
-//     d[1][0] = -(c[0][1]*c[2][2]-c[0][2]*c[2][1])/det;
-//     d[1][1] = (c[0][0]*c[2][2]-c[0][2]*c[2][0])/det;
-//     d[1][2] = -(c[0][0]*c[2][1]-c[0][1]*c[2][0])/det;
-//     d[2][0] =  (c[0][1]*c[1][2]-c[0][2]*c[1][1])/det;
-//     d[2][1] = -(c[0][0]*c[1][2]-c[0][2]*c[1][0])/det;
-//     d[2][2] = (c[0][0]*c[1][1]-c[1][0]*c[0][1])/det;
+    d[0][0] = (c[1][1]*c[2][2]-c[1][2]*c[2][1])/det;
+    d[0][1] = -(c[1][0]*c[2][2]-c[1][2]*c[2][0])/det;
+    d[0][2] =  (c[1][0]*c[2][1]-c[1][1]*c[2][0])/det;
+    d[1][0] = -(c[0][1]*c[2][2]-c[0][2]*c[2][1])/det;
+    d[1][1] = (c[0][0]*c[2][2]-c[0][2]*c[2][0])/det;
+    d[1][2] = -(c[0][0]*c[2][1]-c[0][1]*c[2][0])/det;
+    d[2][0] =  (c[0][1]*c[1][2]-c[0][2]*c[1][1])/det;
+    d[2][1] = -(c[0][0]*c[1][2]-c[0][2]*c[1][0])/det;
+    d[2][2] = (c[0][0]*c[1][1]-c[1][0]*c[0][1])/det;
     
-//     return d;
-// }
+    return d;
+}
 
 } // namespace Sand
 

--- a/vec.h
+++ b/vec.h
@@ -17,15 +17,15 @@ struct vec {
     std::array<GLfloat, N> v;
 
     vec(GLfloat s = GLfloat(0.0)) {
-        std::vector<GLfloat> t(N, s);
-        std::copy_n(t.begin(), N, v.begin());
+        v.fill(s);
     }
 
-    template<typename... T>
+    template<typename... T, 
+        std::enable_if_t<(sizeof...(T) > 1), bool> = true
+    >
     vec(T... vals) {
         static_assert(N == sizeof...(vals), "[vec] : Parameter size should be N");
-        auto t = std::vector<GLfloat>{static_cast<GLfloat>(vals)...};
-        std::copy_n(t.begin(), N, v.begin());
+        v = {static_cast<GLfloat>(vals)...};
     }
     
 
@@ -36,10 +36,8 @@ struct vec {
     vec(const vec<I>& _v, T... vals) {
         static_assert(N == I + sizeof...(vals), "[vec]: Total parameter size should be N");
         auto rest = std::vector<GLfloat>{static_cast<GLfloat>(vals)...};
-        auto t = std::vector<GLfloat>(N);
-        std::copy(_v.v.begin(), _v.v.end(), t.begin());
-        std::copy(rest.begin(), rest.end(), t.begin() + I);
-        std::copy_n(t.begin(), N, v.begin());
+        std::copy(_v.v.begin(), _v.v.end(), v.begin());
+        std::copy(rest.begin(), rest.end(), v.begin() + I);
     }
 
 

--- a/vec.h
+++ b/vec.h
@@ -5,8 +5,8 @@
 
 namespace Sand {
 
-template<typename T>
-std::ostream& operator << (std::ostream& os, const std::vector<T> v) {
+template<typename T, size_t N>
+std::ostream& operator << (std::ostream& os, const std::array<T, N> v) {
     std::copy(v.begin(), v.end()-1, std::ostream_iterator<T>(os, ", "));
     os << *(v.end() - 1);
     return os; 
@@ -14,29 +14,32 @@ std::ostream& operator << (std::ostream& os, const std::vector<T> v) {
 
 template <int N>
 struct vec {
-    std::vector<GLfloat> v;
+    std::array<GLfloat, N> v;
 
     vec(GLfloat s = GLfloat(0.0)) {
-        v = std::vector<GLfloat>(N, s);
+        std::vector<GLfloat> t(N, s);
+        std::copy_n(t.begin(), N, v.begin());
     }
 
     template<typename... T>
     vec(T... vals) {
         static_assert(N == sizeof...(vals), "[vec] : Parameter size should be N");
-        v = std::vector<GLfloat>{static_cast<GLfloat>(vals)...};
+        auto t = std::vector<GLfloat>{static_cast<GLfloat>(vals)...};
+        std::copy_n(t.begin(), N, v.begin());
     }
     
 
     vec(const vec& v) : v(v.v) {}
-    vec(const std::vector<GLfloat>& _v) : v(_v) {}
+    vec(const std::array<GLfloat, N>& _v) : v(_v) {}
     
     template<int I, typename... T>
     vec(const vec<I>& _v, T... vals) {
         static_assert(N == I + sizeof...(vals), "[vec]: Total parameter size should be N");
         auto rest = std::vector<GLfloat>{static_cast<GLfloat>(vals)...};
-        v = std::vector<GLfloat>(N);
-        std::copy(_v.v.begin(), _v.v.end(), v.begin());
-        std::copy(rest.begin(), rest.end(), v.begin() + I);
+        auto t = std::vector<GLfloat>(N);
+        std::copy(_v.v.begin(), _v.v.end(), t.begin());
+        std::copy(rest.begin(), rest.end(), t.begin() + I);
+        std::copy_n(t.begin(), N, v.begin());
     }
 
 
@@ -44,33 +47,33 @@ struct vec {
     const GLfloat operator[](int i) const { return v[i]; } // rvalue
 
     vec operator-() const {
-        std::vector<GLfloat> res(N);
+        std::array<GLfloat,N> res;
         std::transform(v.begin(), v.end(), res.begin(), 
             [](GLfloat x) -> GLfloat { return -x; });
         return vec(res);
     }
     
     vec operator+ (const vec& _v) const { 
-        std::vector<GLfloat> res(N);
+        std::array<GLfloat, N> res;
         std::transform(v.begin(), v.end(), _v.v.begin(), res.begin(), std::plus<>{});
         return vec(res);
     }
     
     vec operator- (const vec& _v) const {
-        std::vector<GLfloat> res(N);
+        std::array<GLfloat, N> res;
         std::transform(v.begin(), v.end(), _v.v.begin(), res.begin(), std::minus<>{});
         return vec(res);
     }
     
     vec operator * (const GLfloat s) const { 
-        std::vector<GLfloat> res(N);
+        std::array<GLfloat, N> res;
         std::transform(v.begin(), v.end(), res.begin(), 
             [s](GLfloat x) -> GLfloat { return s * x; });
         return vec(res);
     }
 
     vec operator * (const vec& _v) const { 
-        std::vector<GLfloat> res(N);
+        std::array<GLfloat, N> res;
         std::transform(v.begin(), v.end(), _v.v.begin(), res.begin(), std::multiplies<>{});
         return vec(res);
     }


### PR DESCRIPTION
In order to send a memory block to opengl, data should be in a contiguous block rather different locations. std::vector parts are replaced with std::array